### PR TITLE
Allow for black border

### DIFF
--- a/src/epd/GxEPD2_154_D67.cpp
+++ b/src/epd/GxEPD2_154_D67.cpp
@@ -349,7 +349,11 @@ void GxEPD2_154_D67::_InitDisplay()
   _writeData(0x00);
   _writeData(0x00);
   _writeCommand(0x3C); // BorderWavefrom
-  _writeData(0x05);
+  #if SCREEN_BLACK_BORDER
+      _writeData(0x00); // Black border
+  #else
+      _writeData(0x05); // White border
+  #endif
   _writeCommand(0x18); // Read built-in temperature sensor
   _writeData(0x80);
   _setPartialRamArea(0, 0, WIDTH, HEIGHT);


### PR DESCRIPTION
Based on having a value SCREEN_BLACK_BORDER defined witch to using a black border, can then be added to platform.io setup like the partial grey workaround